### PR TITLE
Fix binding of named parameters in match queries

### DIFF
--- a/src/Models/MatchModel.php
+++ b/src/Models/MatchModel.php
@@ -98,7 +98,12 @@ class MatchModel
         
         $stmt = $this->pdo->prepare($sql);
         foreach ($params as $key => $value) {
-            $stmt->bindValue($key, $value);
+            $paramName = ':' . $key;
+            if (in_array($key, ['club_id', 'number'], true)) {
+                $stmt->bindValue($paramName, (int) $value, PDO::PARAM_INT);
+                continue;
+            }
+            $stmt->bindValue($paramName, (string) $value, PDO::PARAM_STR);
         }
         $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
@@ -176,7 +181,12 @@ class MatchModel
         
         $stmt = $this->pdo->prepare($sql);
         foreach ($params as $key => $value) {
-            $stmt->bindValue($key, $value);
+            $paramName = ':' . $key;
+            if (in_array($key, ['club_id', 'number'], true)) {
+                $stmt->bindValue($paramName, (int) $value, PDO::PARAM_INT);
+                continue;
+            }
+            $stmt->bindValue($paramName, (string) $value, PDO::PARAM_STR);
         }
         $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();


### PR DESCRIPTION
## Summary
- ensure named parameters in result and upcoming match queries are bound with the required colon prefix
- cast numeric bindings explicitly to integers and set appropriate PDO parameter types to avoid SQLSTATE[HY093]

## Testing
- php -l src/Models/MatchModel.php

------
https://chatgpt.com/codex/tasks/task_e_68e60193d7208321892c9317547c3d65