### PR TITLE
Fix duplicate PDO parameter usage in match and stats queries

### DIFF
--- a/src/Models/MatchModel.php
+++ b/src/Models/MatchModel.php
@@ -37,29 +37,29 @@ class MatchModel
             throw new \InvalidArgumentException('Category and number must be provided together');
         }
         
-        $sql = "SELECT 
+        $sql = "SELECT
             m.id,
             m.ma_no,
             DATE_FORMAT(m.date, '%d/%m/%Y') AS date_fr,
             m.date,
             m.time,
-            CASE 
-                WHEN m.home_club_id = :club_id THEN 'DOM'
+            CASE
+                WHEN m.home_club_id = params.club_id_ref THEN 'DOM'
                 ELSE 'EXT'
             END AS lieu,
             m.home_team_name AS domicile,
             m.home_score,
             m.away_score,
             m.away_team_name AS exterieur,
-            CASE 
-                WHEN m.home_club_id = :club_id THEN
-                    CASE 
+            CASE
+                WHEN m.home_club_id = params.club_id_ref THEN
+                    CASE
                         WHEN m.home_score > m.away_score THEN 'V'
                         WHEN m.home_score < m.away_score THEN 'D'
                         ELSE 'N'
                     END
                 ELSE
-                    CASE 
+                    CASE
                         WHEN m.away_score > m.home_score THEN 'V'
                         WHEN m.away_score < m.home_score THEN 'D'
                         ELSE 'N'
@@ -67,47 +67,52 @@ class MatchModel
             END AS resultat,
             c.name AS competition,
             c.type AS competition_type,
-            CONCAT(COALESCE(e.category_code, 
-                CASE WHEN m.home_club_id = :club_id THEN m.home_team_category ELSE m.away_team_category END
-            ), ' ', 
+            CONCAT(COALESCE(e.category_code,
+                CASE WHEN m.home_club_id = params.club_id_ref THEN m.home_team_category ELSE m.away_team_category END
+            ), ' ',
             COALESCE(e.number,
-                CASE WHEN m.home_club_id = :club_id THEN m.home_team_number ELSE m.away_team_number END
+                CASE WHEN m.home_club_id = params.club_id_ref THEN m.home_team_number ELSE m.away_team_number END
             )) AS equipe_chiche,
             m.poule_journee_number AS journee
         FROM " . DB_PREFIX . "matchs m
         JOIN " . DB_PREFIX . "competitions c ON m.competition_id = c.id
+        JOIN (SELECT :club_id AS club_id_ref) AS params
         LEFT JOIN " . DB_PREFIX . "equipes e ON (
-            (m.home_club_id = :club_id AND e.category_code = m.home_team_category AND e.number = m.home_team_number)
-            OR (m.away_club_id = :club_id AND e.category_code = m.away_team_category AND e.number = m.away_team_number)
-        )
-        WHERE m.is_result = 1
-          AND (m.home_club_id = :club_id OR m.away_club_id = :club_id)";
-        
-        $params = ['club_id' => $this->club_id];
-        
+            (m.home_club_id = params.club_id_ref AND e.category_code = m.home_team_category AND e.number = m.home_team_number)
+            OR (m.away_club_id = params.club_id_ref AND e.category_code = m.away_team_category AND e.number = m.away_team_number)
+        )";
+
         if ($category !== null && $number !== null) {
-            $sql .= " AND (
-                (m.home_club_id = :club_id AND m.home_team_category = :category AND m.home_team_number = :number)
-                OR (m.away_club_id = :club_id AND m.away_team_category = :category AND m.away_team_number = :number)
-            )";
-            $params['category'] = $category;
-            $params['number'] = $number;
+            $sql .= "
+        JOIN (SELECT :category AS category_ref, :number AS number_ref) AS filters";
         }
-        
+
+        $sql .= "
+        WHERE m.is_result = 1
+          AND (m.home_club_id = params.club_id_ref OR m.away_club_id = params.club_id_ref)";
+
+        $params = [':club_id' => $this->club_id];
+
+        if ($category !== null && $number !== null) {
+            $sql .= "
+          AND (
+                (m.home_club_id = params.club_id_ref AND m.home_team_category = filters.category_ref AND m.home_team_number = filters.number_ref)
+                OR (m.away_club_id = params.club_id_ref AND m.away_team_category = filters.category_ref AND m.away_team_number = filters.number_ref)
+            )";
+            $params[':category'] = $category;
+            $params[':number'] = $number;
+        }
+
         $sql .= " ORDER BY m.date DESC, m.time DESC LIMIT :limit";
-        
+
         $stmt = $this->pdo->prepare($sql);
-        foreach ($params as $key => $value) {
-            $paramName = ':' . $key;
-            if (in_array($key, ['club_id', 'number'], true)) {
-                $stmt->bindValue($paramName, (int) $value, PDO::PARAM_INT);
-                continue;
-            }
-            $stmt->bindValue($paramName, (string) $value, PDO::PARAM_STR);
+        foreach ($params as $placeholder => $value) {
+            $type = is_int($value) ? PDO::PARAM_INT : PDO::PARAM_STR;
+            $stmt->bindValue($placeholder, $value, $type);
         }
         $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
-        
+
         return $stmt->fetchAll();
     }
     
@@ -130,15 +135,15 @@ class MatchModel
             throw new \InvalidArgumentException('Category and number must be provided together');
         }
         
-        $sql = "SELECT 
+        $sql = "SELECT
             m.id,
             m.ma_no,
             DATE_FORMAT(m.date, '%d/%m/%Y') AS date_fr,
             DATE_FORMAT(m.date, '%W') AS jour_semaine,
             m.date,
             m.time,
-            CASE 
-                WHEN m.home_club_id = :club_id THEN 'DOM'
+            CASE
+                WHEN m.home_club_id = params.club_id_ref THEN 'DOM'
                 ELSE 'EXT'
             END AS lieu,
             m.home_team_name AS domicile,
@@ -148,45 +153,50 @@ class MatchModel
             t.name AS terrain,
             t.city AS ville_terrain,
             t.address AS adresse_terrain,
-            CONCAT(COALESCE(e.category_code, 
-                CASE WHEN m.home_club_id = :club_id THEN m.home_team_category ELSE m.away_team_category END
-            ), ' ', 
+            CONCAT(COALESCE(e.category_code,
+                CASE WHEN m.home_club_id = params.club_id_ref THEN m.home_team_category ELSE m.away_team_category END
+            ), ' ',
             COALESCE(e.number,
-                CASE WHEN m.home_club_id = :club_id THEN m.home_team_number ELSE m.away_team_number END
+                CASE WHEN m.home_club_id = params.club_id_ref THEN m.home_team_number ELSE m.away_team_number END
             )) AS equipe_chiche,
             m.poule_journee_number AS journee
         FROM " . DB_PREFIX . "matchs m
         JOIN " . DB_PREFIX . "competitions c ON m.competition_id = c.id
         LEFT JOIN " . DB_PREFIX . "terrains t ON m.terrain_id = t.id
+        JOIN (SELECT :club_id AS club_id_ref) AS params
         LEFT JOIN " . DB_PREFIX . "equipes e ON (
-            (m.home_club_id = :club_id AND e.category_code = m.home_team_category AND e.number = m.home_team_number)
-            OR (m.away_club_id = :club_id AND e.category_code = m.away_team_category AND e.number = m.away_team_number)
-        )
-        WHERE m.is_result = 0
-          AND (m.home_club_id = :club_id OR m.away_club_id = :club_id)
-          AND m.date >= CURDATE()";
-        
-        $params = ['club_id' => $this->club_id];
-        
+            (m.home_club_id = params.club_id_ref AND e.category_code = m.home_team_category AND e.number = m.home_team_number)
+            OR (m.away_club_id = params.club_id_ref AND e.category_code = m.away_team_category AND e.number = m.away_team_number)
+        )";
+
         if ($category !== null && $number !== null) {
-            $sql .= " AND (
-                (m.home_club_id = :club_id AND m.home_team_category = :category AND m.home_team_number = :number)
-                OR (m.away_club_id = :club_id AND m.away_team_category = :category AND m.away_team_number = :number)
-            )";
-            $params['category'] = $category;
-            $params['number'] = $number;
+            $sql .= "
+        JOIN (SELECT :category AS category_ref, :number AS number_ref) AS filters";
         }
-        
+
+        $sql .= "
+        WHERE m.is_result = 0
+          AND (m.home_club_id = params.club_id_ref OR m.away_club_id = params.club_id_ref)
+          AND m.date >= CURDATE()";
+
+        $params = [':club_id' => $this->club_id];
+
+        if ($category !== null && $number !== null) {
+            $sql .= "
+          AND (
+                (m.home_club_id = params.club_id_ref AND m.home_team_category = filters.category_ref AND m.home_team_number = filters.number_ref)
+                OR (m.away_club_id = params.club_id_ref AND m.away_team_category = filters.category_ref AND m.away_team_number = filters.number_ref)
+            )";
+            $params[':category'] = $category;
+            $params[':number'] = $number;
+        }
+
         $sql .= " ORDER BY m.date ASC, m.time ASC LIMIT :limit";
-        
+
         $stmt = $this->pdo->prepare($sql);
-        foreach ($params as $key => $value) {
-            $paramName = ':' . $key;
-            if (in_array($key, ['club_id', 'number'], true)) {
-                $stmt->bindValue($paramName, (int) $value, PDO::PARAM_INT);
-                continue;
-            }
-            $stmt->bindValue($paramName, (string) $value, PDO::PARAM_STR);
+        foreach ($params as $placeholder => $value) {
+            $type = is_int($value) ? PDO::PARAM_INT : PDO::PARAM_STR;
+            $stmt->bindValue($placeholder, $value, $type);
         }
         $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
@@ -215,7 +225,7 @@ class MatchModel
             DATE_FORMAT(m.date, '%d/%m/%Y') AS date_fr,
             m.date,
             m.time,
-            CASE WHEN m.home_club_id = :club_id THEN 'DOM' ELSE 'EXT' END AS lieu,
+            CASE WHEN m.home_club_id = params.club_id_ref THEN 'DOM' ELSE 'EXT' END AS lieu,
             m.home_team_name AS domicile,
             m.away_team_name AS exterieur,
             m.home_score,
@@ -229,24 +239,25 @@ class MatchModel
         FROM " . DB_PREFIX . "matchs m
         JOIN " . DB_PREFIX . "competitions c ON m.competition_id = c.id
         LEFT JOIN " . DB_PREFIX . "terrains t ON m.terrain_id = t.id
+        JOIN (SELECT :club_id AS club_id_ref) AS params
         WHERE (
-            (m.home_club_id = :club_id AND m.home_team_category = :category AND m.home_team_number = :number)
-            OR (m.away_club_id = :club_id AND m.away_team_category = :category AND m.away_team_number = :number)
+            (m.home_club_id = params.club_id_ref AND m.home_team_category = :category AND m.home_team_number = :number)
+            OR (m.away_club_id = params.club_id_ref AND m.away_team_category = :category AND m.away_team_number = :number)
         )";
-        
+
         if ($only_upcoming) {
             $sql .= " AND m.is_result = 0 AND m.date >= CURDATE()";
         }
-        
+
         $sql .= " ORDER BY m.date ASC, m.time ASC";
-        
+
         $stmt = $this->pdo->prepare($sql);
         $stmt->execute([
-            'club_id' => $this->club_id,
-            'category' => $category,
-            'number' => $number
+            ':club_id' => $this->club_id,
+            ':category' => $category,
+            ':number' => $number
         ]);
-        
+
         return $stmt->fetchAll();
     }
     
@@ -265,15 +276,15 @@ class MatchModel
             DATE_FORMAT(m.date, '%a %d/%m') AS jour,
             m.date,
             m.time,
-            CONCAT(COALESCE(e.category_code, 
-                CASE WHEN m.home_club_id = :club_id THEN m.home_team_category ELSE m.away_team_category END
-            ), ' ', 
+            CONCAT(COALESCE(e.category_code,
+                CASE WHEN m.home_club_id = params.club_id_ref THEN m.home_team_category ELSE m.away_team_category END
+            ), ' ',
             COALESCE(e.number,
-                CASE WHEN m.home_club_id = :club_id THEN m.home_team_number ELSE m.away_team_number END
+                CASE WHEN m.home_club_id = params.club_id_ref THEN m.home_team_number ELSE m.away_team_number END
             )) AS equipe,
-            CASE WHEN m.home_club_id = :club_id THEN 'DOM' ELSE 'EXT' END AS lieu,
-            CASE 
-                WHEN m.home_club_id = :club_id THEN m.away_team_name
+            CASE WHEN m.home_club_id = params.club_id_ref THEN 'DOM' ELSE 'EXT' END AS lieu,
+            CASE
+                WHEN m.home_club_id = params.club_id_ref THEN m.away_team_name
                 ELSE m.home_team_name
             END AS adversaire,
             c.name AS competition,
@@ -282,18 +293,19 @@ class MatchModel
         FROM " . DB_PREFIX . "matchs m
         JOIN " . DB_PREFIX . "competitions c ON m.competition_id = c.id
         LEFT JOIN " . DB_PREFIX . "terrains t ON m.terrain_id = t.id
+        JOIN (SELECT :club_id AS club_id_ref) AS params
         LEFT JOIN " . DB_PREFIX . "equipes e ON (
-            (m.home_club_id = :club_id AND e.category_code = m.home_team_category AND e.number = m.home_team_number)
-            OR (m.away_club_id = :club_id AND e.category_code = m.away_team_category AND e.number = m.away_team_number)
+            (m.home_club_id = params.club_id_ref AND e.category_code = m.home_team_category AND e.number = m.home_team_number)
+            OR (m.away_club_id = params.club_id_ref AND e.category_code = m.away_team_category AND e.number = m.away_team_number)
         )
         WHERE m.is_result = 0
-          AND (m.home_club_id = :club_id OR m.away_club_id = :club_id)
+          AND (m.home_club_id = params.club_id_ref OR m.away_club_id = params.club_id_ref)
           AND m.date BETWEEN CURDATE() AND DATE_ADD(CURDATE(), INTERVAL 7 DAY)
         ORDER BY m.date ASC, m.time ASC";
-        
+
         $stmt = $this->pdo->prepare($sql);
-        $stmt->execute(['club_id' => $this->club_id]);
-        
+        $stmt->execute([':club_id' => $this->club_id]);
+
         return $stmt->fetchAll();
     }
     
@@ -315,19 +327,19 @@ class MatchModel
             m.home_score,
             m.away_score,
             m.away_team_name AS exterieur,
-            CASE 
-                WHEN m.home_club_id = :club_id THEN 'DOM' 
-                ELSE 'EXT' 
+            CASE
+                WHEN m.home_club_id = params.club_id_ref THEN 'DOM'
+                ELSE 'EXT'
             END AS lieu,
-            CASE 
-                WHEN m.home_club_id = :club_id THEN
-                    CASE 
+            CASE
+                WHEN m.home_club_id = params.club_id_ref THEN
+                    CASE
                         WHEN m.home_score > m.away_score THEN 'Qualifié'
                         WHEN m.home_score = m.away_score THEN 'Prolongations'
                         ELSE 'Éliminé'
                     END
                 ELSE
-                    CASE 
+                    CASE
                         WHEN m.away_score > m.home_score THEN 'Qualifié'
                         WHEN m.away_score = m.home_score THEN 'Prolongations'
                         ELSE 'Éliminé'
@@ -335,22 +347,23 @@ class MatchModel
             END AS statut
         FROM " . DB_PREFIX . "matchs m
         JOIN " . DB_PREFIX . "competitions c ON m.competition_id = c.id
+        JOIN (SELECT :club_id AS club_id_ref) AS params
         WHERE m.is_result = 1
           AND c.type = 'CP'
-          AND (m.home_club_id = :club_id OR m.away_club_id = :club_id)
+          AND (m.home_club_id = params.club_id_ref OR m.away_club_id = params.club_id_ref)
           AND m.id IN (
             SELECT MAX(m2.id)
             FROM " . DB_PREFIX . "matchs m2
             WHERE m2.competition_id = m.competition_id
               AND m2.is_result = 1
-              AND (m2.home_club_id = :club_id OR m2.away_club_id = :club_id)
+              AND (m2.home_club_id = params.club_id_ref OR m2.away_club_id = params.club_id_ref)
             GROUP BY m2.competition_id
           )
         ORDER BY m.date DESC";
-        
+
         $stmt = $this->pdo->prepare($sql);
-        $stmt->execute(['club_id' => $this->club_id]);
-        
+        $stmt->execute([':club_id' => $this->club_id]);
+
         return $stmt->fetchAll();
     }
     


### PR DESCRIPTION
## Summary
- eliminate duplicate named parameters in match result queries by introducing constant JOINs and shared binding logic
- update stats retrieval SQL to use derived constant tables for club/category filters

## Testing
- php -l src/Models/MatchModel.php
- php -l src/Models/Stats.php

------
https://chatgpt.com/codex/tasks/task_e_68e6055ee9f48321b3a41f91209975e6