### PR TITLE
Fix opponent rendering for away matches

### DIFF
--- a/public/assets/js/components.js
+++ b/public/assets/js/components.js
@@ -81,7 +81,7 @@ const Components = {
         assert(match && typeof match === 'object', 'Match must be an object');
         
         const isHome = match.lieu === 'DOM';
-        const homeTeam = isHome ? 'CHICHE FC' : match.exterieur;
+        const homeTeam = isHome ? 'CHICHE FC' : match.domicile;
         const awayTeam = isHome ? match.exterieur : 'CHICHE FC';
         const placeholderLogo = this.assetPath('images/placeholder-logo.svg');
         const clubLogo = this.assetPath('images/logo.svg');
@@ -96,8 +96,8 @@ const Components = {
         let resultBadge = '';
         
         if (isResult && match.home_score !== null) {
-            const homeScore = isHome ? match.home_score : match.away_score;
-            const awayScore = isHome ? match.away_score : match.home_score;
+            const homeScore = match.home_score;
+            const awayScore = match.away_score;
             
             scoreHTML = `
                 <div class="match-score">


### PR DESCRIPTION
## Summary
- ensure away match cards display the opponent name from the domicile field
- keep home and away scores aligned with the displayed teams

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6274cd0308321b0b06485ca90ae90